### PR TITLE
Security fixes

### DIFF
--- a/actions/XUploadAction.php
+++ b/actions/XUploadAction.php
@@ -78,6 +78,13 @@ class XUploadAction extends CAction {
     public $publicPath;
 
     /**
+     * @var boolean dictates whether to use sha1 to hash the file names
+     * along with time and the user id to make it much harder for malicious users
+     * to attempt to delete another user's file
+     */
+    public $secureFileNames = false;
+
+    /**
      * Name of the state variable the file array is stored in
      * @see XUploadAction::init()
      * @var string
@@ -159,7 +166,7 @@ class XUploadAction extends CAction {
                 echo json_encode( $success );
             }
         } else {
-            $model = Yii::createComponent($this->formClass);
+            $model = Yii::createComponent(array('class'=>$this->formClass,'secureFileNames'=>$this->secureFileNames));
             $model->file = CUploadedFile::getInstance( $model, 'file' );
             if( $model->file !== null ) {
                 $model->mime_type = $model->file->getType( );

--- a/models/XUploadForm.php
+++ b/models/XUploadForm.php
@@ -6,6 +6,14 @@ class XUploadForm extends CFormModel
         public $size;
         public $name;
         public $filename;
+
+        /**
+         * @var boolean dictates whether to use sha1 to hash the file names
+         * along with time and the user id to make it much harder for malicious users
+         * to attempt to delete another user's file
+        */
+        public $secureFileNames = false;
+
         /**
          * Declares the validation rules.
          * The rules state that username and password are required,
@@ -52,5 +60,22 @@ class XUploadForm extends CFormModel
          */
         public function getThumbnailUrl($publicPath) {
             return $publicPath.$this->filename;
+        }
+
+        /**
+         * Change our filename to match our own naming convention
+        * @return bool
+        */
+        public function beforeValidate() {
+
+            //(optional) Generate a random name for our file to work on preventing
+            // malicious users from determining / deleting other users' files
+            if($this->secureFileNames)
+            {
+                $this->filename = sha1( Yii::app( )->user->id.microtime( ).$this->name);
+                $this->filename .= ".".$this->file->getExtensionName( );
+            }
+
+            return parent::beforeValidate();
         }
 }


### PR DESCRIPTION
These fixes attempt to prevent malicious users from deleting any file writeable by the webserver or files uploaded by another user that the malicious user shouldn't be able to delete.

I made it backwards compatible to keep from breaking current installations, but I'd suggest we add info to the docs on the Yii extension page about the secureFileNames flag for the action and recommend its use.
